### PR TITLE
Comet fixes

### DIFF
--- a/reactive-web/src/main/resources/toserve/reactive-web.js
+++ b/reactive-web/src/main/resources/toserve/reactive-web.js
@@ -188,14 +188,33 @@ window.reactive = {
       this.error(e);
     }
   },
+  smartReplace: function(el, content) {
+    try {
+      if (content.indexOf('<') == 0 && $) {
+        $(el).html($(content))
+      } else {
+        el.innerHTML = content;
+      }
+    } catch (e) {
+      reactive.error(e);
+    }
+  },
   replaceAll : function(parentId, innerHtml) {
     try {
       var p = document.getElementById(parentId);
-      if (!p)
-        this.error("Error in replaceAll('" + parentId + "','" + innerHtml
-            + "'): no element " + parentId);
-      else
-        p.innerHTML = innerHtml;
+      if (!p) {
+        setTimeout(function() {
+            p = document.getElementById(parentId);
+            if (!p)
+                reactive.error("Error in replaceAll('" + parentId + "','" +
+                    innerHtml + "'): no element " + parentId);
+            else {
+              reactive.smartReplace(p, innerHtml);
+            }
+        }, 200);
+      } else {
+        reactive.smartReplace(p, innerHtml);
+      }
     } catch (e) {
       this.error(e);
     }
@@ -203,9 +222,16 @@ window.reactive = {
   updateProperty : function(parentId, propertyName, value) {
     try {
       var p = document.getElementById(parentId);
-      if (!p)
-        this.error("Error in updateProperty('" + parentId + "','"
-            + propertyName + "'," + value + "): no element " + parentId);
+      if (!p) {
+          setTimeout(function() {
+              p = document.getElementById(parentId);
+              if (!p)
+                  reactive.error("Error in updateProperty('" + parentId + "','"
+                  + propertyName + "'," + value + "): no element " + parentId);
+              else
+                  p[propertyName] = value;
+          }, 200);
+      }
       else
         p[propertyName] = value;
     } catch (e) {

--- a/reactive-web/src/main/resources/toserve/reactive-web.js
+++ b/reactive-web/src/main/resources/toserve/reactive-web.js
@@ -200,42 +200,35 @@ window.reactive = {
     }
   },
   replaceAll : function(parentId, innerHtml) {
-    try {
-      var p = document.getElementById(parentId);
-      if (!p) {
-        setTimeout(function() {
-            p = document.getElementById(parentId);
-            if (!p)
-                reactive.error("Error in replaceAll('" + parentId + "','" +
-                    innerHtml + "'): no element " + parentId);
-            else {
-              reactive.smartReplace(p, innerHtml);
-            }
-        }, 200);
-      } else {
-        reactive.smartReplace(p, innerHtml);
-      }
-    } catch (e) {
-      this.error(e);
+    var maxTries = 300;
+    function doReplace() {
+        var p = document.getElementById(parentId);
+        if (!p && maxTries != 0) {
+            setTimeout(doReplace, 150);
+        } else if (!p) {
+            reactive.error("Error in replaceAll('" + parentId + "','" +
+                innerHtml + "'): no element " + parentId);
+        } else {
+            reactive.smartReplace(p, innerHtml);
+        }
+        maxTries = maxTries - 1;
     }
+    doReplace();
   },
   updateProperty : function(parentId, propertyName, value) {
-    try {
-      var p = document.getElementById(parentId);
-      if (!p) {
-          setTimeout(function() {
-              p = document.getElementById(parentId);
-              if (!p)
-                  reactive.error("Error in updateProperty('" + parentId + "','"
-                  + propertyName + "'," + value + "): no element " + parentId);
-              else
-                  p[propertyName] = value;
-          }, 200);
+      var maxTries = 300;
+      function doUpdate() {
+          var p = document.getElementById(parentId);
+          if (!p && maxTries != 0) {
+              setTimeout(doUpdate, 150);
+          } else if (!p) {
+              reactive.error("Error in updateProperty('" + parentId + "','"
+                + propertyName + "'," + value + "): no element " + parentId);
+          } else {
+              p[propertyName] = value;
+          }
+          maxTries = maxTries - 1;
       }
-      else
-        p[propertyName] = value;
-    } catch (e) {
-      this.error(e);
-    }
+      doUpdate();
   }
 };


### PR DESCRIPTION
1. ProcessingCometTransport allows tracking when comet action is in progress

This makes possible to detour S.addAround() wrappers which get executed during comet message processing because of S.initIfUninitted() call
1. smartReplace() and setTimeout() changes in js make reactive more stable.

Added smartReplace to handle invalid html better with jQuery (if it's present) and added setTimeouts to retry commands later (reactive mixes up commands order sometimes). Dirty, but this makes reactive more stable.
